### PR TITLE
fix(backend/modules/auth): repo 이름을 생성할 때 생기는 버그를 수정

### DIFF
--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -34,7 +34,9 @@ export class AuthService {
             Authorization: `Bearer ${this.SERVER_ACCESS_TOKEN}`,
         };
 
-        const repoName = `BoostPress-${data.login}-${randomUUID().split('-')}`;
+        const repoName = `BoostPress-${data.login}-${
+            randomUUID().split('-')[0]
+        }`;
 
         // 사용자 github에 repoName으로 repo 생성
         await this.axios.post(


### PR DESCRIPTION
repo 이름을 생성할 때 uuid를 split한 뒤 원소를 고르지 않고 그대로 사용하던 오류를 수정

BREAKING CHANGE: repo 이름을 생성할 떄 생기는 버그를 수정

fix #35