### PR TITLE
fix(backend/category): 카테고리가 부모 카테고리를 지니지 않을 수 있도록 수정

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -59,8 +59,8 @@ model Category {
     ownerId Int
     owner   User @relation(fields: [ownerId], references: [id])
 
-    parentCategoryId Int
-    parentCategory   Category   @relation(name: "CategoryTree", fields: [parentCategoryId], references: [id])
+    parentCategoryId Int?
+    parentCategory   Category?  @relation(name: "CategoryTree", fields: [parentCategoryId], references: [id])
     childCategory    Category[] @relation(name: "CategoryTree")
 
     articles Article[]


### PR DESCRIPTION
카테고리를 생성 혹은 수정할 때 부모 카테고리를 지니지 않을 수 있도록 수정

fix #39