### PR TITLE
fix(backend/blog): 사용자의 SNS 링크를 기존 API 명세에 맞게끔 변경

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -23,15 +23,21 @@ model User {
     bio      String
     imageURL String
 
-    // SNS 관련
-    twitterLink  String?
-    facebookLink String?
-    linkedinLink String?
-
     // join 관련
     session    Session?
     categories Category[]
     articles   Article[]
+    snsLink    UserSNS[]
+}
+
+model UserSNS {
+    id     Int    @id @default(autoincrement())
+    userId Int
+    user   User   @relation(fields: [userId], references: [id])
+    name   String
+    link   String
+
+    @@unique([userId, name])
 }
 
 model Session {

--- a/backend/src/modules/blog/dto/Patch.dto.ts
+++ b/backend/src/modules/blog/dto/Patch.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsOptional, IsString } from 'class-validator';
+import { SNSDTO } from './SNS.dto';
 
 export class PatchDTO {
     @IsString()
@@ -24,16 +25,6 @@ export class PatchDTO {
 
     @IsString()
     @IsOptional()
-    @ApiProperty({ description: '사용자의 트위터 페이지 URL' })
-    twitterLink: string;
-
-    @IsString()
-    @IsOptional()
-    @ApiProperty({ description: '사용자의 페이스북 페이지 URLL' })
-    facebookLink: string;
-
-    @IsString()
-    @IsOptional()
-    @ApiProperty({ description: '사용자의 링크드인 사진 URL' })
-    linkedinLink: string;
+    @ApiProperty({ description: '사용자의 SNS 링크', type: [SNSDTO] })
+    snsLink: SNSDTO[];
 }

--- a/backend/src/modules/blog/dto/Response.dto.ts
+++ b/backend/src/modules/blog/dto/Response.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { User } from '@prisma/client';
+import { User, UserSNS } from '@prisma/client';
+import { SNSDTO } from './SNS.dto';
 
 class TagInfoDTO {
     @ApiProperty({ description: '태그의 ID' })
@@ -10,6 +11,10 @@ class TagInfoDTO {
 
     @ApiProperty({ description: '해당 태그를 가진 게시글의 개수' })
     articleCount: number;
+}
+
+export class JoinDTO {
+    snsLink: UserSNS[];
 }
 
 export class BlogBriefResponseDTO {
@@ -25,33 +30,18 @@ export class BlogBriefResponseDTO {
     @ApiProperty({ description: '사용자의 프로필 사진 URL' })
     imageURL: string;
 
-    @ApiProperty({ description: '사용자의 트위터 페이지 URL' })
-    twitterLink: string;
+    @ApiProperty({ description: '사용자의 SNS 페이지 URL' })
+    snsLink: SNSDTO[];
 
-    @ApiProperty({ description: '사용자의 페이스북 페이지 URLL' })
-    facebookLink: string;
+    static toBrief(user: User & JoinDTO) {
+        const { nickname, bio, blogName, imageURL, snsLink } = user;
 
-    @ApiProperty({ description: '사용자의 링크드인 사진 URL' })
-    linkedinLink: string;
-
-    static toBrief(user: User) {
-        const {
-            nickname,
-            bio,
-            blogName,
-            imageURL,
-            twitterLink,
-            facebookLink,
-            linkedinLink,
-        } = user;
         return {
             nickname,
             bio,
             blogName,
             imageURL,
-            twitterLink,
-            facebookLink,
-            linkedinLink,
+            snsLink: snsLink.map(SNSDTO.toExport),
         };
     }
 }

--- a/backend/src/modules/blog/dto/SNS.dto.ts
+++ b/backend/src/modules/blog/dto/SNS.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { UserSNS } from '@prisma/client';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class SNSDTO {
+    @IsString()
+    @IsNotEmpty()
+    @ApiProperty({ description: 'SNS의 이름' })
+    snsName: string;
+    @IsString()
+    @IsNotEmpty()
+    @ApiProperty({ description: 'SNS의 링크' })
+    link: string;
+
+    static toExport(snsLink: UserSNS): SNSDTO {
+        const { name, link } = snsLink;
+        return { snsName: name, link };
+    }
+}

--- a/backend/src/modules/blog/dto/index.ts
+++ b/backend/src/modules/blog/dto/index.ts
@@ -1,2 +1,3 @@
 export * from './Patch.dto';
 export * from './Response.dto';
+export * from './SNS.dto';


### PR DESCRIPTION
사용자의 각 SNS 링크를 {이름, 링크} 꼴의 객체의 배열로 바꿔 저장하도록 변경

fix #86